### PR TITLE
feat: 特定商取引法に基づく表記・プライバシーポリシーページを追加

### DIFF
--- a/src/app/privacy/page.js
+++ b/src/app/privacy/page.js
@@ -1,0 +1,87 @@
+import '../../styles/legal.css';
+
+export const metadata = {
+  title: 'プライバシーポリシー - Alphard',
+  description: '株式会社アルファルドのプライバシーポリシーページです。',
+};
+
+export default function PrivacyPage() {
+  return (
+    <section className="legal-section">
+      <div className="legal-container">
+        <div className="legal-content">
+          <h2 className="legal-title ja-text">プライバシーポリシー</h2>
+
+          <p className="legal-intro ja-text">
+            株式会社アルファルド（以下「当社」）は、お客様の個人情報の保護に関し、以下のとおりプライバシーポリシーを定めます。
+          </p>
+
+          <h3 className="legal-subtitle ja-text">1. 収集する情報</h3>
+          <p className="legal-text ja-text">
+            当社は、チケット予約・イベント運営に際して、以下の情報を取得することがあります。
+          </p>
+          <ul className="legal-list ja-text">
+            <li>お名前（LINE表示名を含む）</li>
+            <li>メールアドレス</li>
+            <li>LINE ユーザーID</li>
+            <li>決済に必要な情報（Stripe社が管理。当社はカード情報を保持しません）</li>
+          </ul>
+
+          <h3 className="legal-subtitle ja-text">2. 利用目的</h3>
+          <p className="legal-text ja-text">取得した情報は以下の目的で利用します。</p>
+          <ul className="legal-list ja-text">
+            <li>チケット予約の受付・管理・確認連絡</li>
+            <li>イベント当日の受付・本人確認</li>
+            <li>イベント運営に関するご案内（LINE配信を含む）</li>
+            <li>お問い合わせへの対応</li>
+            <li>サービスの改善・統計分析（個人を特定しない形で利用）</li>
+          </ul>
+
+          <h3 className="legal-subtitle ja-text">3. 第三者への提供</h3>
+          <p className="legal-text ja-text">
+            当社は、以下の場合を除き、ご本人の同意なく個人情報を第三者に提供することはありません。
+          </p>
+          <ul className="legal-list ja-text">
+            <li>法令に基づく場合</li>
+            <li>決済処理に必要な範囲でStripe社に提供する場合</li>
+            <li>人の生命、身体または財産の保護のために必要な場合</li>
+          </ul>
+
+          <h3 className="legal-subtitle ja-text">4. 情報の管理</h3>
+          <p className="legal-text ja-text">
+            当社は個人情報の漏洩・紛失・改ざんを防止するため、適切なセキュリティ対策を講じます。
+            データは暗号化された通信（SSL/TLS）を使用して送受信し、アクセス権限を適切に管理します。
+          </p>
+
+          <h3 className="legal-subtitle ja-text">5. 個人情報の開示・訂正・削除</h3>
+          <p className="legal-text ja-text">
+            ご本人から個人情報の開示・訂正・削除のご請求があった場合は、ご本人確認のうえ、合理的な期間内に対応いたします。
+          </p>
+
+          <h3 className="legal-subtitle ja-text">6. Cookieの使用</h3>
+          <p className="legal-text ja-text">
+            本サービスでは、ログイン状態の管理のためにCookieを使用します。
+            Cookieを無効にした場合、一部の機能がご利用いただけない場合があります。
+          </p>
+
+          <h3 className="legal-subtitle ja-text">7. ポリシーの変更</h3>
+          <p className="legal-text ja-text">
+            当社は本ポリシーを変更する場合があります。変更後のポリシーは本ページに掲載した時点で効力を生じるものとします。
+          </p>
+
+          <h3 className="legal-subtitle ja-text">8. お問い合わせ</h3>
+          <p className="legal-text ja-text">
+            個人情報に関するお問い合わせは、以下までご連絡ください。<br />
+            株式会社アルファルド<br />
+            メール: support@alphard.info
+          </p>
+
+          <p className="legal-date ja-text">
+            制定日: 2026年4月1日<br />
+            株式会社アルファルド
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/app/tokushoho/page.js
+++ b/src/app/tokushoho/page.js
@@ -1,0 +1,96 @@
+import '../../styles/legal.css';
+
+export const metadata = {
+  title: '特定商取引法に基づく表記 - Alphard',
+  description: '株式会社アルファルドの特定商取引法に基づく表記ページです。',
+};
+
+export default function TokushohoPage() {
+  return (
+    <section className="legal-section">
+      <div className="legal-container">
+        <div className="legal-content">
+          <h2 className="legal-title ja-text">特定商取引法に基づく表記</h2>
+
+          <div className="legal-table">
+            <div className="info-row">
+              <div className="info-label ja-text">販売業者</div>
+              <div className="info-content ja-text">株式会社アルファルド</div>
+            </div>
+
+            <div className="info-row">
+              <div className="info-label ja-text">運営統括責任者</div>
+              <div className="info-content ja-text">柿添 泰裕</div>
+            </div>
+
+            <div className="info-row">
+              <div className="info-label ja-text">所在地</div>
+              <div className="info-content ja-text">
+                請求があった場合には遅滞なく開示いたします。<br />
+                お問い合わせ先: support@alphard.info
+              </div>
+            </div>
+
+            <div className="info-row">
+              <div className="info-label ja-text">電話番号</div>
+              <div className="info-content ja-text">
+                請求があった場合には遅滞なく開示いたします。<br />
+                お問い合わせ先: support@alphard.info
+              </div>
+            </div>
+
+            <div className="info-row">
+              <div className="info-label ja-text">メールアドレス</div>
+              <div className="info-content ja-text">support@alphard.info</div>
+            </div>
+
+            <div className="info-row">
+              <div className="info-label ja-text">販売URL</div>
+              <div className="info-content ja-text">https://alphard-admin.vercel.app</div>
+            </div>
+
+            <div className="info-row">
+              <div className="info-label ja-text">販売価格</div>
+              <div className="info-content ja-text">各イベントページに記載の金額（税込）</div>
+            </div>
+
+            <div className="info-row">
+              <div className="info-label ja-text">商品代金以外の必要料金</div>
+              <div className="info-content ja-text">なし（別途ドリンク代等が必要な場合はイベントページに記載）</div>
+            </div>
+
+            <div className="info-row">
+              <div className="info-label ja-text">支払方法</div>
+              <div className="info-content ja-text">
+                クレジットカード決済（Stripe経由）<br />
+                Apple Pay / Google Pay
+              </div>
+            </div>
+
+            <div className="info-row">
+              <div className="info-label ja-text">支払時期</div>
+              <div className="info-content ja-text">予約時に即時決済</div>
+            </div>
+
+            <div className="info-row">
+              <div className="info-label ja-text">商品の引渡時期</div>
+              <div className="info-content ja-text">
+                決済完了後、LINE にて予約確認メッセージを送信いたします。<br />
+                イベント当日、受付にてお名前を確認のうえご入場いただけます。
+              </div>
+            </div>
+
+            <div className="info-row">
+              <div className="info-label ja-text">返品・キャンセルについて</div>
+              <div className="info-content ja-text">
+                イベントの性質上、お客様都合による返品・返金は原則としてお受けできません。<br />
+                主催者都合によるイベント中止・延期の場合は全額返金いたします。<br />
+                キャンセルのご連絡は運営公式LINEアカウントまでお願いいたします。
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -26,6 +26,8 @@ export default function Footer() {
               <li><Link href="/works">WORKS</Link></li>
               <li><Link href="/about">ABOUT</Link></li>
               <li><Link href="/contact">CONTACT</Link></li>
+              <li><Link href="/tokushoho">特定商取引法に基づく表記</Link></li>
+              <li><Link href="/privacy">プライバシーポリシー</Link></li>
             </ul>
           </div>
         </div>

--- a/src/styles/legal.css
+++ b/src/styles/legal.css
@@ -1,0 +1,115 @@
+/* 法的情報ページ（特定商取引法・プライバシーポリシー）のスタイル */
+
+.legal-section {
+  width: 100%;
+  padding: 0;
+}
+
+.legal-container {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 100px 20px 50px;
+}
+
+.legal-content {
+  width: 100%;
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+.legal-title {
+  font-size: 28px;
+  text-align: center;
+  margin-bottom: 60px;
+  font-weight: 500;
+  position: relative;
+  letter-spacing: 0.05em;
+}
+
+.legal-intro {
+  margin-bottom: 40px;
+  line-height: 1.8;
+  font-size: 14px;
+}
+
+.legal-subtitle {
+  font-size: 18px;
+  margin: 40px 0 16px;
+  font-weight: 500;
+  letter-spacing: 0.03em;
+}
+
+.legal-text {
+  margin-bottom: 16px;
+  line-height: 1.8;
+  font-size: 14px;
+}
+
+.legal-list {
+  margin: 0 0 24px 20px;
+  line-height: 2;
+  font-size: 14px;
+}
+
+.legal-list li {
+  margin-bottom: 4px;
+}
+
+.legal-date {
+  margin-top: 60px;
+  font-size: 13px;
+  color: var(--text-secondary, #888);
+  line-height: 1.8;
+}
+
+/* 特定商取引法の表形式 */
+.legal-table {
+  width: 100%;
+}
+
+.legal-table .info-row {
+  display: flex;
+  border-bottom: 1px solid var(--about-line-color, #333);
+  padding: 16px 0;
+}
+
+.legal-table .info-label {
+  width: 200px;
+  min-width: 200px;
+  font-weight: 500;
+  font-size: 14px;
+}
+
+.legal-table .info-content {
+  flex: 1;
+  font-size: 14px;
+  line-height: 1.8;
+}
+
+@media (max-width: 600px) {
+  .legal-container {
+    padding: 80px 16px 40px;
+  }
+
+  .legal-title {
+    font-size: 22px;
+    margin-bottom: 40px;
+  }
+
+  .legal-table .info-row {
+    flex-direction: column;
+    gap: 4px;
+    padding: 12px 0;
+  }
+
+  .legal-table .info-label {
+    width: auto;
+    min-width: auto;
+    font-size: 13px;
+    color: var(--text-secondary, #888);
+  }
+
+  .legal-table .info-content {
+    font-size: 14px;
+  }
+}


### PR DESCRIPTION
## Summary
- `/tokushoho` 特定商取引法に基づく表記ページを追加（Stripe審査対応、決済一時停止の解消）
- `/privacy` プライバシーポリシーページを追加
- フッターナビに両ページへのリンクを追加
- `legal.css` でAboutページと統一されたデザイン（レスポンシブ対応）

closes #2

## Test plan
- [ ] `/tokushoho` ページが表示される
- [ ] `/privacy` ページが表示される
- [ ] フッターからリンクされている
- [ ] モバイルでレイアウトが崩れない
- [ ] Stripe に再提出して審査通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)